### PR TITLE
Add spurious IAR cmsis manager files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ CMSIS/CoreValidation/Tests/build
 CMSIS/CoreValidation/Tests/bootloader/build
 *.uvguix.*
 *.uvmpw.uvgui.*
+**.dep
+**.rteconfig
+**/.project


### PR DESCRIPTION
See https://github.com/IARSystems/iar-vsc-build/issues/37

TL;DR IAR's vscode extension generates a lot of garbage in this repository. To tamp down on the annoyance of it all I'm proposing adding the generated files to the `.gitignore` here.
